### PR TITLE
Remove hostname setting from default zabbix_agentd.conf

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,6 +15,9 @@ do
 done > "${config_file}"
 # generate config -- end
 
+# remove hostname setting from default zabbix_agentd.conf
+sed -i 's/Hostname=Zabbix server/# Hostname=Zabbix server/g' /etc/zabbix/zabbix_agentd.conf
+
 # create fifo as logfile so we don't waste disk space
 log_file=/var/log/zabbix/zabbix_agentd.log
 [ ! -e ${log_file} ] && mkfifo ${log_file} && chown zabbix:zabbix ${log_file}


### PR DESCRIPTION
 Remove hostname setting from default zabbix_agentd.conf, so it gets the real host name when not set.